### PR TITLE
fix:未定義の変数を参照してエラーが起きる問題の修正

### DIFF
--- a/issue_checker.py
+++ b/issue_checker.py
@@ -20,6 +20,8 @@ class IssueChecker:
             # 出力例をそのままprintfするやつをしばくやつ
             with open(filepath) as f:
                 code = exclude_comments(f.read())
+
+                excluded_code = code
                 #  オプションがあった場合標準出力結果から文字を除外する
                 if 'exclude' in check_code:
                     for char in check_code["exclude"]:


### PR DESCRIPTION
check_codeのkeyに'excluede'が存在しない場合excluded_codeが定義されず未定義のまま呼び出されてエラーが出るので条件に関わらずあらかじめ定義しておく